### PR TITLE
Register callback for cached loads after the first one

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,7 @@ export default class InlineSVG extends React.PureComponent {
       }
 
       if (!getRequestsByUrl[src]) {
-        getRequestsByUrl[src] = [callback];
+        getRequestsByUrl[src] = [];
 
         http.get(src, (err, res) => {
           getRequestsByUrl[src].forEach(cb => {
@@ -114,6 +114,8 @@ export default class InlineSVG extends React.PureComponent {
           });
         });
       }
+
+      getRequestsByUrl[src].push(callback);
     }
     else {
       http.get(src, (err, res) => {


### PR DESCRIPTION
The recent refactor broke cached loads, since callbacks after the first one weren't added to the list of callbacks.