### PR TITLE
Fix example of use

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ import SVG  from 'react-inlinesvg';
 <SVG
     src="/path/to/myfile.svg"
     preload={<Loader />}
-    onLoad: src => {
+    onLoad={(src) => {
         myOnLoadHandler(src);
-    }
+    }}
 >
   Here's some optional content for browsers that don't support XHR or inline
   SVGs. You can use other React components here too. Here, I'll show you.


### PR DESCRIPTION
Current example doesn't work, lack `{}` and use `:` instead of `=`