### PR TITLE
Update Read Me with install

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ information and [this table][use-support] for browser support and caveats.
 
 [![Code Sponsor](https://app.codesponsor.io/embed/aVyak7F2JA5ZCo4usjUoY8he/gilbarbara/react-inlinesvg.svg)](https://app.codesponsor.io/link/aVyak7F2JA5ZCo4usjUoY8he/gilbarbara/react-inlinesvg)
 
+ 
+Instal
+----
+ 
+ ```
+ $ npm install react-inlinesvg --save
+ ```
 
 Usage
 ----


### PR DESCRIPTION
The readme misses the NPM installation.
When you want to try out a library, you want to grab the installation, paste in the terminal and install right away.
 It's just easier when it's explicit in the readme.