### PR TITLE
Fix/render performance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ export default class InlineSVG extends React.PureComponent {
       if (loadedIcons[src]) {
         const [err, res] = loadedIcons[src];
 
-        setTimeout(() => callback(err, res, true), 0);
+        callback(err, res, true);
       }
 
       if (!getRequestsByUrl[src]) {
@@ -169,7 +169,9 @@ export default class InlineSVG extends React.PureComponent {
         loadedText: res.text,
         status: Status.LOADED
       }, () => {
-        this.props.onLoad(this.props.src, isCached);
+        setTimeout(() => {
+          this.props.onLoad(this.props.src, isCached);
+        }, 0);
       });
     }
   };

--- a/src/index.js
+++ b/src/index.js
@@ -169,9 +169,7 @@ export default class InlineSVG extends React.PureComponent {
         loadedText: res.text,
         status: Status.LOADED
       }, () => {
-        setTimeout(() => {
-          this.props.onLoad(this.props.src, isCached);
-        }, 0);
+        this.props.onLoad(this.props.src, isCached);
       });
     }
   };


### PR DESCRIPTION
Remove the setTimeout for when the image is already loaded.
The "callback" calls setState which triggers the render, when there's a setTimeout it delays the render for no reason.