### PR TITLE
Uniqueify IDs in style

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -36,12 +36,12 @@ export const randomString = (length = 8) => {
 export const uniquifySVGIDs = (() => {
   const mkAttributePattern = attr => `(?:(?:\\s|\\:)${attr})`;
 
-  const idPattern = new RegExp(`(?:(${(mkAttributePattern('id'))})="([^"]+)")|(?:(${(mkAttributePattern('href'))}|${(mkAttributePattern('role'))}|${(mkAttributePattern('arcrole'))})="\\#([^"]+)")|(?:="url\\(\\#([^\\)]+)\\)")`, 'g');
+  const idPattern = new RegExp(`(?:(${(mkAttributePattern('id'))})="([^"]+)")|(?:(${(mkAttributePattern('href'))}|${(mkAttributePattern('role'))}|${(mkAttributePattern('arcrole'))})="\\#([^"]+)")|(?:="url\\(\\#([^\\)]+)\\)")|(?:url\\(\\#([^\\)]+)\\))`, 'g');
 
   return (svgText, svgID) => {
     const uniquifyID = id => `${id}___${svgID}`;
 
-    return svgText.replace(idPattern, (m, p1, p2, p3, p4, p5) => { //eslint-disable-line consistent-return
+    return svgText.replace(idPattern, (m, p1, p2, p3, p4, p5, p6) => { //eslint-disable-line consistent-return
       /* istanbul ignore else */
       if (p2) {
         return `${p1}="${(uniquifyID(p2))}"`;
@@ -51,6 +51,9 @@ export const uniquifySVGIDs = (() => {
       }
       else if (p5) {
         return `="url(#${(uniquifyID(p5))})"`;
+      }
+      else if (p6) {
+        return `url(#${uniquifyID(p6)})`;
       }
     });
   };

--- a/test/__fixtures__/style.svg
+++ b/test/__fixtures__/style.svg
@@ -1,0 +1,12 @@
+<svg baseProfile="basic" width="223" height="222" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="a" gradientUnits="userSpaceOnUse" x1="185.5" y1="145.75" x2="199.5" y2="145.75">
+      <stop offset="0%" stop-color="#FFF" stop-opacity="0"/>
+      <stop offset="100%" stop-color="#FFF"/>
+    </linearGradient>
+  </defs>
+  <g overflow="visible">
+    <path fill="#3D91DF" d="M185.5 90.75v110h14v-110h-14z"/>
+    <path d="M199.5 200.75v-110h-14v110h14z" style="fill:url(#a)"/>
+  </g>
+</svg>

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -150,6 +150,22 @@ describe('react-inlinesvg', () => {
       });
     });
 
+    it('should uniquify ids in the style attribute', done => {
+      const wrapper = setup({
+        src: '/test/__fixtures__/style.svg',
+        preloader: (<div className="loader">loading</div>),
+        onError: done,
+        onLoad: () => {
+          wrapper.update();
+          const html = wrapper.find('.isvg').html();
+
+          expect(/fill:url\(#a___/.test(html)).toBe(true);
+
+          done();
+        }
+      });
+    });
+
     it('should not uniquify ids if it\'s disabled', done => {
       const wrapper = setup({
         src: 'https://raw.githubusercontent.com/gilbarbara/logos/00cf8501d18b9e377ec0227b915a6f74ab4bd18f/logos/apiary.svg',


### PR DESCRIPTION
There are some IDs in style that weren't being replaced. Things like:

```
<rect style="fill:url(#id-here-that-was-not-unique-but-now-is)"/>
```

This is fixed in this PR.