### PR TITLE
fix example code to match documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ import SVG  from 'react-inlinesvg';
 
 <SVG
     src="/path/to/myfile.svg"
-    preload={<Loader />}
+    preloader={<Loader />}
     onLoad={(src) => {
         myOnLoadHandler(src);
     }}


### PR DESCRIPTION
This updates example code to use the `preloader` prop instead of `preload`.