### PR TITLE
remove old option from babelify config

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,8 +108,7 @@
       [
         "babelify",
         {
-          "ignore": "/bower_components/",
-          "sourceMapRelative": "."
+          "ignore": "/bower_components/"
         }
       ]
     ]


### PR DESCRIPTION
bug from #91 

Hey there so looking into this issue. I have notice its fairly easy to replicate.

[Here is an example that exhibits the issue](https://github.com/jcblw/parcel-react-inlinesvg-bug)

At first I thought this was a bug with [parcel-bundler](https://github.com/parcel-bundler/parcel) which is the bundler for the project. Parcel does load in [browserify transforms](https://github.com/parcel-bundler/parcel/blob/master/src/transforms/babel.js#L168).

Then I found this in the [babelify repo](https://github.com/babel/babelify/commit/6997ff5bec307269978545e5295b46fc9f399f42). 

> sourceMapRelative hasn't worked in babelify 7.x. The behavior up to now, with and without the option, has been to always have source maps relative to the basedir (or `process.cwd()` if not set). This is what browserify will do when given sources paths that are just the base name.