### PR TITLE
Add processSVG prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ A string to use with `uniquifyIDs`.
 **baseURL** {string}
 An URL to prefix each ID in case you are using the `<base>` tag.
 
+**processSVG** {function} ▶︎ `string`
+A function to process the contents of the SVG text before rendering.
+
 **onLoad** {function} ▶︎ a random 8 characters string `[A-Za-z0-9]`  
 A callback to be invoked upon successful load.  
 This will receive 2 arguments: the `src` prop and a `isCached` boolean

--- a/src/index.js
+++ b/src/index.js
@@ -191,9 +191,15 @@ export default class InlineSVG extends React.PureComponent {
     return className;
   }
 
-  processSVG(svgText) {
-    const { uniquifyIDs, uniqueHash, baseURL, processSVG } = this.props;
+  processSVG(text) {
+    const {
+      uniquifyIDs,
+      uniqueHash,
+      baseURL,
+      processSVG
+    } = this.props;
 
+    let svgText = text;
     if (processSVG) {
       svgText = processSVG(svgText);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ export default class InlineSVG extends React.PureComponent {
     onError: PropTypes.func,
     onLoad: PropTypes.func,
     preloader: PropTypes.node,
+    processSVG: PropTypes.func,
     src: PropTypes.string.isRequired,
     style: PropTypes.object,
     supportTest: PropTypes.func,
@@ -191,7 +192,11 @@ export default class InlineSVG extends React.PureComponent {
   }
 
   processSVG(svgText) {
-    const { uniquifyIDs, uniqueHash, baseURL } = this.props;
+    const { uniquifyIDs, uniqueHash, baseURL, processSVG } = this.props;
+
+    if (processSVG) {
+      svgText = processSVG(svgText);
+    }
 
     if (uniquifyIDs) {
       return uniquifySVGIDs(svgText, uniqueHash || randomString(), baseURL);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -232,6 +232,27 @@ describe('react-inlinesvg', () => {
       });
     });
 
+    it('should transform the SVG text when given the processSVG prop', done => {
+      const extraProp = 'data-isvg="test"';
+      const wrapper = setup({
+        src: fixtures.url,
+        processSVG: svgText =>
+          svgText.replace('<svg ', `<svg ${extraProp}`),
+        onError: done,
+        onLoad: () => {
+          wrapper.update();
+          const html = wrapper.find('.isvg').html();
+
+          const regexp = new RegExp(extraProp);
+          expect(!!regexp.exec(html)).toBe(true);
+
+          done();
+        }
+      });
+
+      expect(wrapper.instance() instanceof React.Component).toBe(true);
+    });
+
     it('should handle unmount', () => {
       const wrapper = setup({
         src: fixtures.url,


### PR DESCRIPTION
Hi

For my use case, I need to be able to edit the attributes of the loaded SVG. Seeing as the SVG is rendered as a string (dangerously), this PR adds a `processSVG` prop which allows you to specify a function that can mutate the SVG string before render.

It's up the user of the component to decide how to parse the SVG string and add attributes to it. But naively it should be like:

```js
<InlineSvg
  {...myOtherProps}
  processSVG={svgText => {
    // Replace any fills with CSS currentColor
    return svgText.replace(/fill="[A-Za-z0-9(),#]+"/g, 'fill="currentColor"');
  }}
/>
```

Admittedly, it's quite open to failure so I could also make a PR with a different solution to properly replace attributes on the `<svg>` tag like `uniquifySVGIDs` does.

Looks like there are a few open issues with people wanting to edit the SVG before render.

#105, #90, #97