### PR TITLE
Fix Object.values incorrect polyfilling with additional check

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -114,13 +114,13 @@ export default class InlineSVG extends React.PureComponent<Props, State> {
       if (d.attributes && d.attributes.length) {
         const attributes = Object.values(d.attributes).map((a) => {
           const attr = a;
-          let match = [];
+          let match;
 
           if (typeof a.value === 'string') {
             match = a.value.match(/url\((.*?)\)/);
           }
 
-          if (match[1]) {
+          if (match && match[1]) {
             attr.value = a.value.replace(match[0], `url(${baseURL}${match[1]}__${this.hash})`);
           }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -114,9 +114,13 @@ export default class InlineSVG extends React.PureComponent<Props, State> {
       if (d.attributes && d.attributes.length) {
         const attributes = Object.values(d.attributes).map((a) => {
           const attr = a;
-          const match = a.value.match(/url\((.*?)\)/);
+          let match = [];
 
-          if (match && match[1]) {
+          if (typeof a.value === 'string') {
+            match = a.value.match(/url\((.*?)\)/);
+          }
+
+          if (match[1]) {
             attr.value = a.value.replace(match[0], `url(${baseURL}${match[1]}__${this.hash})`);
           }
 


### PR DESCRIPTION
@gilbarbara 
I ran into a problem when Object values were polyfilled on the site, added a check so that there was no error.
For example, the site https://www.educom.at/. Errors in the console.