### PR TITLE
fix SSR scenarios,  converting SVG to a string ,In this context, the associated lifecycle hooks are not executed

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -342,7 +342,7 @@ export default class InlineSVG extends React.PureComponent<Props, State> {
 
   public render(): React.ReactNode {
     const { element, status } = this.state;
-    const { children = null, innerRef, loader = null } = this.props;
+    const { children = null, innerRef, loader = null, src } = this.props;
     const elementProps = omit(
       this.props,
       'baseURL',
@@ -371,6 +371,17 @@ export default class InlineSVG extends React.PureComponent<Props, State> {
 
     if ([STATUS.UNSUPPORTED, STATUS.FAILED].includes(status)) {
       return children;
+    }
+
+    // SSR scenarios,  converting SVG to a string ,In this context, the associated lifecycle hooks are not executed,
+    if (!loader && !this.isActive) {
+      const dataURI = src.match(/data:image\/svg[^,]*?(;base64)?,(.*)/);
+
+      if (dataURI) {
+        const inlineSrc = dataURI[1] ? window.atob(dataURI[2]) : decodeURIComponent(dataURI[2]);
+
+        return convert(inlineSrc) as React.ReactNode;
+      }
     }
 
     return loader;

--- a/test/index.spec.tsx
+++ b/test/index.spec.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { renderToString } from 'react-dom/server';
 import { render, waitFor } from '@testing-library/react';
 import fetchMock from 'jest-fetch-mock';
 
@@ -675,6 +676,12 @@ describe('react-inlinesvg', () => {
           new Error('Could not convert the src to a React element'),
         );
       });
+    });
+
+    it('SSR scenario, should render a svg string src', async () => {
+      expect(
+        renderToString(<ReactInlineSVG onLoad={mockOnLoad} src={fixtures.string} />),
+      ).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
I tried to fix an issue where rendering SVG with renderToString was empty,
This is my first time submitting a PR request，If there is any unreasonable, please give suggestions.