### PR TITLE
fix: Add support of browsers not supporting unicode regexp

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -104,7 +104,16 @@ function ReactInlineSVG(props: Props) {
   }, [content, handleError, props]);
 
   const getContent = useCallback(async () => {
-    const dataURI = /^data:image\/svg[^,]*?(;base64)?,(.*)/u.exec(src);
+    let dataURI: ReturnType<typeof RegExp.prototype.exec>;
+    const regexp = /^data:image\/svg[^,]*?(;base64)?,(.*)/;
+
+    try {
+      dataURI = new RegExp(regexp.source, 'u').exec(src);
+    } catch {
+      // Enables support of browsers not supporting /u
+      dataURI = regexp.exec(src);
+    }
+
     let inlineSrc;
 
     if (dataURI) {


### PR DESCRIPTION
Hi, when running the package in old browsers (Chrome < 50) I get the error "Invalid flags supplied to RegExp constructor 'u'". This is because of this [line](https://github.com/gilbarbara/react-inlinesvg/blob/c4db6b26c8d58805714be980a7d1ca98db27f60c/src/index.tsx#L107) of code:

```
const dataURI = /^data:image\/svg[^,]*?(;base64)?,(.*)/u.exec(src);
```

This feature (`/u`) is supported from Chrome 50: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#browser_compatibility

Why could somebody need to support Chrome 50? I am developing a WebOS/Tizen web based app. Some not so old TV devices use these old Chrome versions under the hood to run apps:

- WebOS 3: https://webostv.developer.lge.com/develop/specifications/web-api-and-web-engine
- Tizen 3: https://developer.samsung.com/smarttv/develop/specifications/web-engine-specifications.html

As the main page of this repo effectively mentions support for Chrome 42+ (from which `fetch` is supported) or even older with `fetch` polyfill, it would be great to change the line to something processable in old browsers.