### PR TITLE
Generate the unique hash lazily so renders stay deterministic

### DIFF
--- a/src/modules/useInlineSVG.ts
+++ b/src/modules/useInlineSVG.ts
@@ -24,7 +24,7 @@ export default function useInlineSVG(props: Props, cacheStore: CacheStore) {
     uniquifyIDs,
   } = props;
 
-  const hash = useRef(uniqueHash ?? randomString(8));
+  const hashRef = useRef(uniqueHash);
   const fetchOptionsRef = useRef(fetchOptions);
   const onErrorRef = useRef(onError);
   const onLoadRef = useRef(onLoad);
@@ -34,6 +34,14 @@ export default function useInlineSVG(props: Props, cacheStore: CacheStore) {
   onErrorRef.current = onError;
   onLoadRef.current = onLoad;
   preProcessorRef.current = preProcessor;
+
+  const getHash = useCallback(() => {
+    const hash = hashRef.current ?? randomString(8);
+
+    hashRef.current = hash;
+
+    return hash;
+  }, []);
 
   const [state, setState] = useReducer(
     (previousState: State, nextState: Partial<State>) => ({
@@ -59,7 +67,7 @@ export default function useInlineSVG(props: Props, cacheStore: CacheStore) {
         const node = getNode({
           ...props,
           handleError: () => {},
-          hash: hash.current,
+          hash: getHash(),
           content: cachedContent,
         });
 
@@ -113,7 +121,7 @@ export default function useInlineSVG(props: Props, cacheStore: CacheStore) {
         content,
         description,
         handleError,
-        hash: hash.current,
+        hash: getHash(),
         preProcessor: preProcessorRef.current,
         src,
         title,
@@ -132,7 +140,7 @@ export default function useInlineSVG(props: Props, cacheStore: CacheStore) {
     } catch (error: any) {
       handleError(error);
     }
-  }, [baseURL, content, description, handleError, src, title, uniquifyIDs]);
+  }, [baseURL, content, description, getHash, handleError, src, title, uniquifyIDs]);
 
   // Mount
   useMount(() => {

--- a/test/prerender.spec.tsx
+++ b/test/prerender.spec.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { render, waitFor } from '@testing-library/react';
+
+import InlineSVG, { cacheStore } from '../src';
+
+/**
+ * Frameworks that prerender client components at build time reject any
+ * non-deterministic value read during render. Next.js with `cacheComponents`
+ * enabled patches `Math.random`, `Date.now` and `crypto.randomUUID` to detect
+ * this, and aborts the enclosing Suspense boundary when one is called.
+ *
+ * The unique hash is only consumed when `uniquifyIDs` is set, and only once the
+ * SVG content has loaded — which requires the DOM. It must therefore never be
+ * generated during a server render.
+ */
+describe('server rendering', () => {
+  const fixtures = {
+    play: 'http://127.0.0.1:1337/play.svg',
+    url: 'https://cdn.svglogos.dev/logos/react.svg',
+    urlEncoded:
+      'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M8%205v14l11-7z%22%2F%3E%3C%2Fsvg%3E',
+  } as const;
+
+  let randomSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    randomSpy = vi.spyOn(Math, 'random');
+  });
+
+  afterEach(() => {
+    randomSpy.mockRestore();
+  });
+
+  it.each([
+    ['a remote url', { src: fixtures.url }],
+    ['a data uri', { src: fixtures.urlEncoded }],
+    ['uniquifyIDs', { src: fixtures.url, uniquifyIDs: true }],
+    ['a custom uniqueHash', { src: fixtures.url, uniqueHash: 'test', uniquifyIDs: true }],
+  ])('should not call Math.random when rendering with %s', (_, props) => {
+    renderToStaticMarkup(<InlineSVG {...props} />);
+
+    expect(randomSpy).not.toHaveBeenCalled();
+  });
+
+  it('should still uniquify ids once the content is rendered on the client', async () => {
+    const { container } = render(<InlineSVG src={fixtures.play} uniquifyIDs />);
+
+    await waitFor(() => {
+      expect(container.querySelector('radialGradient')).not.toBeNull();
+    });
+
+    expect(randomSpy).toHaveBeenCalled();
+    expect(container.querySelector('radialGradient')?.getAttribute('id')).toEqual(
+      expect.stringMatching(/^radialGradient-1__.+/),
+    );
+  });
+
+  it('should use one hash for every id when rendering from a warm cache', async () => {
+    // The cached branch of the reducer initializer is the only place the hash is
+    // read during a render, so it needs to stay stable across a StrictMode
+    // double render.
+    const view = render(<InlineSVG src={fixtures.play} uniquifyIDs />);
+
+    await waitFor(() => {
+      expect(view.container.querySelector('radialGradient')).not.toBeNull();
+    });
+
+    expect(cacheStore.isCached(fixtures.play)).toBe(true);
+
+    const { container } = render(
+      <React.StrictMode>
+        <InlineSVG src={fixtures.play} uniquifyIDs />
+      </React.StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('radialGradient')).not.toBeNull();
+    });
+
+    const suffixes = new Set(
+      [...container.querySelectorAll('[id]')].map(node => node.getAttribute('id')?.split('__')[1]),
+    );
+
+    expect(suffixes.size).toBe(1);
+    expect([...suffixes][0]).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes #253.

### The problem

`src/modules/useInlineSVG.ts:27`

```ts
const hash = useRef(uniqueHash ?? randomString(8));
```

`useRef`'s argument is evaluated eagerly on every render, and `??` evaluates its right operand whenever `uniqueHash` is undefined — so `randomString(8)` runs on each render even though only the first result is kept.

That makes the component impossible to statically prerender under Next.js 16 with `cacheComponents`, which patches `Math.random` at build time and aborts the enclosing Suspense boundary when it is called. The abort is silent, and it freezes every later boundary as client-rendered in the stored artifact. Full mechanism and repro in #253.

### The change

Hold `uniqueHash` in the ref and fill in a random string on first read:

```ts
const hashRef = useRef(uniqueHash);

const getHash = useCallback(() => {
  const hash = hashRef.current ?? randomString(8);

  hashRef.current = hash;

  return hash;
}, []);
```

The two read sites — the `useReducer` initializer and `getElement` — now call `getHash()`.

This works because the hash is only read when `uniquifyIDs` is set (`getNode` returns early otherwise at `utils.ts:59`, `updateSVGAttributes` at `utils.ts:115`), and only once `content` exists. Content loading happens in the mount effect behind `canUseDOM()`, so on a server render the hash is never reached — and now never generated.

`getHash` is memoized deliberately: an unstable identity would flow into `getElement`'s dependency array and re-trigger the `LOADED -> READY` effect on every render.

I kept the syntax at ES2020 to match `tsconfig.json`'s `target`. `??=` would read better here, but it is ES2021 and `tsdown` emits it unchanged, so it would have been the first logical-assignment operator in the shipped bundle — a syntax-floor bump for a package that supports `react: 16.8 - 19`.

### Behaviour

Unchanged in every case:

- a supplied `uniqueHash` is used verbatim, exactly as before;
- an omitted one still resolves to one stable random string for the lifetime of the component;
- an empty-string `uniqueHash` is still preserved (`??` does not treat `''` as nullish, same as before);
- a `uniqueHash` that arrives after mount is still ignored, as it was before.

I deliberately avoided `useId()`: it would be the semantically ideal source for this, but it needs React 18+ and the package supports `16.8 - 19`. Worth revisiting if that floor ever moves.

### Tests

New `test/prerender.spec.tsx`:

- `Math.random` is never called during `renderToStaticMarkup`, across a remote URL, a data URI, `uniquifyIDs`, and a custom `uniqueHash`;
- ids are still uniquified once content renders on the client;
- rendering from a warm cache under `StrictMode` yields a single hash for every id. That path — the cached branch of the reducer initializer — is the only place the hash is read during a render, so it is the one that most needed covering.

Verified these are real regression tests, not tautologies: with `src/modules/useInlineSVG.ts` reverted to `main` and the tests left in place, 3 of the 6 fail. (The other 3 should pass either way — a custom `uniqueHash` short-circuits the old expression, and the two client-side tests assert behaviour the old code also had.)

`pnpm run validate` is green — lint, typecheck, 100 tests (94 before, 6 new), build, size limit (7.13 kB ESM against the 10 kB budget), and `attw`.
